### PR TITLE
Better example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,19 @@ This GitHub Action sets a pull request status to pending if the title includes "
 An example workflow looks like this (switch to the <kbd>`<> Edit new file`</kbd> tab when creating a new workflow and paste the code below):
 
 ```yml
-on: [pull_request]
-name: "Set status on pull_request"
+name: Set PR review status
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
 
 jobs:
   wip:
-  name: "Set status"
-  runs-on: ubuntu-latest
-  steps:
-    - uses: wip/action@master
+    name: Set WIP status
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: wip/action@master
 ```
 
 ## Contributing


### PR DESCRIPTION
This is a cool action :) I struggled a bit with errors, but have figured them out and thought I should open a PR to update your README.

The current readme doesn't actually work, as it doesn't include the reference to the `GITHUB_TOKEN` env. I also think that for most people, this is going to need to be executed when the title of a PR is updated, so I updated the example triggers as well.

This would resolve #15 