### PR TITLE
fix: Use v14 LTS docker image to fix issues since v15 which is not LTS and the node:slim image has been upgraded to

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:14-slim
 
 # A bunch of `LABEL` fields for GitHub to index
 LABEL "com.github.actions.name"="WIP"


### PR DESCRIPTION
Should fix issue #26 

node:slim docker image has been updated to Node v15. So it's either use v14 which gets my vote as it is the LTS version or regenerate the package-lock.json file with Node 15 (assumed alternate fix).